### PR TITLE
Remove 10.x from version matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ['10.x', '12.x', '14.x']
+        node: ['12.x', '14.x']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:


### PR DESCRIPTION
A temporary fix until we remove `next.js` from the deps but still allow builds to pass for the time being.

`next.js` only builds with node 12