### PR TITLE
Keep track of the modalName 

### DIFF
--- a/example/src/Modal1.tsx
+++ b/example/src/Modal1.tsx
@@ -1,0 +1,3 @@
+export default function Modal1() {
+  return <div>No params! Simple stuff</div>;
+}

--- a/example/src/Modal2.tsx
+++ b/example/src/Modal2.tsx
@@ -1,0 +1,3 @@
+export default function Modal2({ params }: any) {
+  return <div>{params.stuff}</div>;
+}

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -1,6 +1,8 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import React from 'react';
+import ReactDOM from 'react-dom';
 import { ModalWrapper, openModal } from '../../';
+import Modal1 from './Modal1';
+import Modal2 from './Modal2';
 
 const App = () => {
   return (
@@ -19,7 +21,7 @@ const App = () => {
           openModal({
             name: 'thing2',
             params: {
-              hello: 'world',
+              stuff: 'hello world',
             },
           })
         }
@@ -40,8 +42,8 @@ const App = () => {
 };
 
 const modals = {
-  thing: () => 'sup',
-  thing2: ({ params }) => JSON.stringify(params),
+  thing: Modal1,
+  thing2: Modal2,
   thing3: React.lazy(() => import('./Modal3')),
 };
 

--- a/src/hooks/useCustomEvent.tsx
+++ b/src/hooks/useCustomEvent.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 export default function useCustomEvent(
   eventName: string,
-  listener: () => void
+  listener: EventListenerOrEventListenerObject
 ) {
   useEffect(() => {
     window.addEventListener(eventName, listener);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,17 +4,8 @@ import useCustomEvent from './hooks/useCustomEvent';
 export const PARAMS_KEY = 'params';
 export const MODAL_KEY = 'modal';
 
-const routerPush = async (href: string) => {
-  let nextRouter;
-
-  try {
-    nextRouter = (await import('next/router')).default;
-
-    return nextRouter.push(href, undefined, { shallow: true });
-  } catch {}
-
-  return window.history.pushState({ path: href }, '', href);
-};
+const routerPush = async (href: string) =>
+  window.history.pushState({ path: href }, '', href);
 
 const createURL = (urlParams: {}) => {
   const {
@@ -85,8 +76,7 @@ export const isModalOpen = (name: string): boolean => {
 };
 
 export type ModalChildren =
-  | any
-  | React.Component<(...args: any) => JSX.Element>
+  | ((...args: any) => JSX.Element)
   | React.LazyExoticComponent<(...args: any) => JSX.Element>;
 
 export interface ModalWrapperProps {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,8 +4,17 @@ import useCustomEvent from './hooks/useCustomEvent';
 export const PARAMS_KEY = 'params';
 export const MODAL_KEY = 'modal';
 
-const routerPush = async (href: string) =>
-  window.history.pushState({ path: href }, '', href);
+const routerPush = async (href: string) => {
+  let nextRouter;
+
+  try {
+    nextRouter = (await import('next/router')).default;
+
+    return nextRouter.push(href, undefined, { shallow: true });
+  } catch {}
+
+  return window.history.pushState({ path: href }, '', href);
+};
 
 const createURL = (urlParams: {}) => {
   const {
@@ -42,7 +51,15 @@ export const openModal = ({
   }
 
   routerPush(createURL(urlParams));
-  const event = new CustomEvent('modal-trigger', { detail: props });
+  const event = new CustomEvent('modal-trigger', {
+    detail: {
+      modalName: name,
+      props: {
+        params,
+        ...props,
+      },
+    },
+  });
   window.dispatchEvent(event);
 };
 
@@ -55,6 +72,7 @@ export const closeModal = () => {
   urlParams.delete(MODAL_KEY);
 
   routerPush(createURL(urlParams));
+
   window.dispatchEvent(new Event('modal-trigger'));
   window.dispatchEvent(new Event(`${modalName}-close`));
 };
@@ -66,44 +84,63 @@ export const isModalOpen = (name: string): boolean => {
   return modalName === name;
 };
 
-export const ModalWrapper = ({
-  modals,
-  Wrapper,
-}: {
+export type ModalChildren =
+  | any
+  | React.Component<(...args: any) => JSX.Element>
+  | React.LazyExoticComponent<(...args: any) => JSX.Element>;
+
+export interface ModalWrapperProps {
   modals: {
-    [name: string]:
-      | React.ElementType
-      | React.LazyExoticComponent<() => JSX.Element>;
+    [name: string]: ModalChildren;
   };
   Wrapper: React.ElementType;
-}): React.ReactNode => {
-  const [show, setShow] = useState(false);
+}
+
+export function ModalWrapper({ modals, Wrapper }: ModalWrapperProps) {
   const [extraProps, setExtraProps] = useState({});
   const urlParams = new URLSearchParams(window.location.search);
+  const [modalName, setModalName] = useState<string | null>(
+    urlParams.get(MODAL_KEY)
+  );
 
-  const listener = useCallback(
+  const popStateListener = useCallback(
     (event?: any) => {
       const urlParams = new URLSearchParams(window.location.search);
       const modalQuery = urlParams.get(MODAL_KEY);
 
       if (!modalQuery) {
-        setShow(false);
+        setModalName(null);
         setExtraProps({});
       }
       if (modalQuery && modals[modalQuery]) {
-        setShow(true);
-        if (event?.detail) setExtraProps(event.detail);
+        setModalName(modalQuery);
+        if (event?.detail) setExtraProps(event.detail.props);
       }
     },
     [modals]
   );
-  useCustomEvent('modal-trigger', listener);
-  useCustomEvent('popstate', listener);
+  const modalTriggerListener = useCallback(
+    (event: any) => {
+      const { modalName, props } = event.detail || {};
+
+      if (!modalName) {
+        setModalName(null);
+        setExtraProps({});
+      }
+      if (modalName && modals[modalName]) {
+        setExtraProps(props);
+        setModalName(modalName);
+      }
+    },
+    [modals]
+  );
+  useCustomEvent('modal-trigger', modalTriggerListener);
+  useCustomEvent('popstate', popStateListener);
 
   useEffect(() => {
     // load modal if a modal is on the url at load
-    listener();
-  }, [listener]);
+    popStateListener();
+  }, [popStateListener]);
 
   if (typeof window === 'undefined') return null;
 
@@ -116,37 +153,34 @@ export const ModalWrapper = ({
       return null;
     }
   };
-  const modalName = urlParams.get(MODAL_KEY);
+
   const onSubmit = () => window.dispatchEvent(new Event(`${modalName}-submit`));
 
   const onClose = () => closeModal();
 
   const Component = modalName ? modals[modalName] : null;
 
-  if (!show || !Component) return null;
+  if (!Component) return null;
+
   const WrapperEl = Wrapper ? Wrapper : React.Fragment;
   const wrapperProps = Wrapper
     ? {
-        visible: show,
+        visible: !!Component,
         onCancel: onClose,
         onDismiss: onClose,
       }
     : {};
-  return (
-    <>
-      <WrapperEl {...wrapperProps}>
-        <Suspense fallback={false}>
-          <Component
-            onCancel={onClose}
-            open={show}
-            onSubmit={onSubmit}
-            params={getData()}
-            {...extraProps}
-          />
-        </Suspense>
-      </WrapperEl>
-    </>
-  );
-};
 
-export { Modal } from './Modal';
+  return (
+    <WrapperEl {...wrapperProps}>
+      <Suspense fallback={false}>
+        <Component
+          onCancel={onClose}
+          onSubmit={onSubmit}
+          params={getData()}
+          {...extraProps}
+        />
+      </Suspense>
+    </WrapperEl>
+  );
+}


### PR DESCRIPTION
This wasn't working at all, with the full vanilla approach. We need to keep track of the modal name because `pushState` triggers no events.

Split up the listeners for the popstate and our custom event. Also sends the props and modalName to the component so we render correctly.

Also fixes up the example repo so it also works nicely.