### PR TITLE
Make the example paths prettier

### DIFF
--- a/example/src/components/Examples.tsx
+++ b/example/src/components/Examples.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { openModal, URLModal } from '../../../';
-import { Modal } from '../../../dist/Modal';
+import { openModal, URLModal } from 'react-url-modal';
+import { Modal } from 'react-url-modal/Modal';
 const StandardModalContent = () => <>No params! Simple stuff</>;
 
 const ModalWithParams = ({ params }: { params: { [key: string]: string } }) => (

--- a/example/src/components/Modals/Modal3.tsx
+++ b/example/src/components/Modals/Modal3.tsx
@@ -1,4 +1,4 @@
-import { Modal } from '../../../../dist/Modal';
+import { Modal } from 'react-url-modal/Modal';
 
 export default function Modal3(props: unknown) {
   return <Modal {...props}>I am loaded from another file</Modal>;

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -14,7 +14,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "react-url-modal": ["../dist"],
+      "react-url-modal/*": ["../dist/*"]
+    }
   },
   "include": ["./src"]
 }

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -1,9 +1,21 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-
+console.log(__dirname);
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: [
+      {
+        find: /^react-url-modal$/,
+        replacement: __dirname + '/../dist/react-url-modal.esm.js',
+      },
+      {
+        find: /^react-url-modal\/Modal$/,
+        replacement: __dirname + '/../dist/Modal/index.js',
+      },
+    ],
+  },
   server: {
     fs: {
       // Allow serving files from one level up to the project root

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-console.log(__dirname);
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "test": "jest",
     "posttest": "npm run format",
     "lint": "eslint \"src/**/*.{js,jsx,ts,tsx}\"",
-    "prepare": "npm run build",
     "size": "size-limit",
     "format": "prettier --loglevel warn --write \"**/*.{ts,tsx,css,md}\"",
     "build": "rollup -c",


### PR DESCRIPTION
I also removed the `prepare` script. Doesn't make sense as we are going to use a github that publishes to NPM.... right? 😅 

This PR makes the paths prettier with a nice alias. On vite and ts so everyone is happy!