### PR TITLE
Fix nil params when transitioning from a modal to another

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "main": "dist/react-url-modal.cjs.js",
   "module": "dist/react-url-modal.esm.js",

--- a/src/URLModal.tsx
+++ b/src/URLModal.tsx
@@ -119,8 +119,6 @@ export const URLModal = ({
       }
     : {};
 
-  console.log(modalState);
-
   return (
     <RootEl {...rootElProps}>
       <WrapperEl {...wrapperProps}>

--- a/src/URLModal.tsx
+++ b/src/URLModal.tsx
@@ -28,6 +28,29 @@ export interface ModalWrapperProps {
   replace?: boolean;
 }
 
+interface ModalState {
+  name?: string | null;
+  params?: Record<string, unknown> | null;
+  extraProps?: Record<string, unknown> | null;
+}
+
+function urlIntoModalState(): ModalState {
+  const urlParams =
+    typeof window !== 'undefined'
+      ? new URLSearchParams(window.location.search)
+      : { get: () => null };
+  const modalName = urlParams.get(MODAL_KEY);
+  const encodedParams = urlParams.get(PARAMS_KEY);
+
+  if (!modalName) return { name: null, extraProps: {}, params: {} };
+
+  return {
+    name: modalName,
+    params: decodedUrlParams(encodedParams),
+    extraProps: {},
+  };
+}
+
 export const URLModal = ({
   modals,
   Wrapper,
@@ -36,29 +59,13 @@ export const URLModal = ({
   adapter,
   replace,
 }: ModalWrapperProps) => {
-  store.setState({ adapter: adapter || null, replace });
-  const [extraProps, setExtraProps] = useState({});
-  const urlParams =
-    typeof window !== 'undefined'
-      ? new URLSearchParams(window.location.search)
-      : { get: () => null };
-  const [modalName, setModalName] = useState<string | null>(
-    urlParams.get(MODAL_KEY)
-  );
+  const [modalState, setModalState] = useState<ModalState>(urlIntoModalState());
 
   const popStateListener = useCallback(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const modalQuery = urlParams.get(MODAL_KEY);
+    setModalState(urlIntoModalState());
 
-    if (!modalQuery) {
-      setModalName(null);
-      setExtraProps({});
-    }
-
-    if (modalQuery && modals[modalQuery]) {
-      setModalName(modalQuery);
-    }
-    // run this when location search changes
+    // Run this when location search changes
+    //
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modals, typeof window !== 'undefined' ? window.location.search : {}]);
   const modalTriggerListener = useCallback(
@@ -66,13 +73,15 @@ export const URLModal = ({
       const { modalName, props } = event.detail || {};
 
       if (!modalName) {
-        setModalName(null);
-        setExtraProps({});
+        setModalState({ name: null, extraProps: {}, params: {} });
       }
 
       if (modalName && modals[modalName]) {
-        setExtraProps(props);
-        setModalName(modalName);
+        setModalState({
+          name: modalName,
+          extraProps: props,
+          params: props.params,
+        });
       }
     },
     [modals]
@@ -81,23 +90,17 @@ export const URLModal = ({
   useCustomEvent('popstate', popStateListener);
 
   useEffect(() => {
+    store.setState({ adapter: adapter || null, replace });
+  }, [adapter, replace]);
+
+  useEffect(() => {
     // load modal if a modal is on the url at load
     popStateListener();
   }, [popStateListener]);
 
   if (typeof window === 'undefined') return null;
 
-  const getData = () => {
-    const urlData = urlParams.get(PARAMS_KEY);
-    if (!urlData) return null;
-    try {
-      return decodedUrlParams();
-    } catch {
-      return null;
-    }
-  };
-
-  const Component = modalName ? modals[modalName] : null;
+  const Component = modalState.name ? modals[modalState.name] : null;
 
   if (!Component) return null;
 
@@ -116,6 +119,8 @@ export const URLModal = ({
       }
     : {};
 
+  console.log(modalState);
+
   return (
     <RootEl {...rootElProps}>
       <WrapperEl {...wrapperProps}>
@@ -124,11 +129,11 @@ export const URLModal = ({
             onCancel={closeModal}
             onClose={closeModal}
             onSubmit={() =>
-              window.dispatchEvent(new Event(`${modalName}-submit`))
+              window.dispatchEvent(new Event(`${modalState.name}-submit`))
             }
-            params={getData()}
-            modalName={modalName}
-            {...extraProps}
+            params={modalState.params}
+            modalName={modalState.name}
+            {...modalState.extraProps}
           />
         </Suspense>
       </WrapperEl>

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -98,7 +98,7 @@ export const openModal = async ({ name, params, ...props }: openModalProps) => {
 
   urlParams.set(MODAL_KEY, name);
   if (params) urlParams.set(PARAMS_KEY, encodeUrlParams(params));
-  console.log('urlpush', urlParams.toString());
+
   await routerPush(createURL(urlParams));
 
   const event = new CustomEvent('modal-trigger', {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -67,31 +67,24 @@ const routerPush = async (href: string) => {
   }
 };
 
-const routerReplace = async (href: string) => {
-  if (store.getState().adapter === 'nextjs') {
-    await nextRouterAction({ href, replace: true });
-  } else {
-    window.history.replaceState({ path: href }, '', href);
-  }
-};
 export const cleanSearchParams = () => {
   const urlParams = new URLSearchParams(window.location.search);
 
   if (urlParams.get(PARAMS_KEY)) urlParams.delete(PARAMS_KEY);
   if (urlParams.get(MODAL_KEY)) urlParams.delete(MODAL_KEY);
 
-  return createURL(urlParams);
+  return urlParams;
 };
 
 export const encodeUrlParams = (
   obj: URLSearchParams | Record<string, unknown>
 ): string => window.btoa(encodeURI(JSON.stringify(obj)));
 
-export const decodedUrlParams = () => {
-  const params = new URLSearchParams(window.location.search).get(PARAMS_KEY);
-  if (params) {
-    return JSON.parse(decodeURI(window.atob(params)));
+export const decodedUrlParams = (encodedParams: string | undefined | null) => {
+  if (encodedParams) {
+    return JSON.parse(decodeURI(window.atob(encodedParams)));
   }
+
   return {};
 };
 
@@ -101,12 +94,11 @@ export const isModalOpen = (name: string): boolean => {
 };
 
 export const openModal = async ({ name, params, ...props }: openModalProps) => {
-  await routerReplace(cleanSearchParams());
-  const urlParams = new URLSearchParams(window.location.search);
+  const urlParams = new URLSearchParams(cleanSearchParams());
 
   urlParams.set(MODAL_KEY, name);
   if (params) urlParams.set(PARAMS_KEY, encodeUrlParams(params));
-
+  console.log('urlpush', urlParams.toString());
   await routerPush(createURL(urlParams));
 
   const event = new CustomEvent('modal-trigger', {
@@ -125,7 +117,7 @@ export const closeModal = async () => {
   const urlParams = new URLSearchParams(window.location.search);
   const modalName = urlParams.get(MODAL_KEY);
 
-  await routerPush(cleanSearchParams());
+  await routerPush(createURL(cleanSearchParams()));
   window.dispatchEvent(new Event('modal-trigger'));
   window.dispatchEvent(new Event(`${modalName}-close`));
 };

--- a/src/test/helpers.test.ts
+++ b/src/test/helpers.test.ts
@@ -71,23 +71,14 @@ describe('test encodeUrlParams', () => {
 });
 
 describe('test decodedUrlParams', () => {
-  beforeEach(() => {
-    createFakeWindowLocation({
-      params: 'JTdCJTIyc2VhcmNoJTIyOiUyMnRlc3QlMjIlN0Q',
-    });
-  });
-
-  afterEach(() => {
-    global.window.location = realLocation;
-  });
-
   it('should decode when its URLSearchParams', () => {
-    createFakeWindowLocation({});
-    expect(decodedUrlParams()).toEqual({});
+    expect(decodedUrlParams('')).toEqual({});
   });
 
   it('should return an empty object when nothing is passed', () => {
-    expect(decodedUrlParams()).toEqual({ search: 'test' });
+    expect(decodedUrlParams('JTdCJTIyc2VhcmNoJTIyOiUyMnRlc3QlMjIlN0Q')).toEqual(
+      { search: 'test' }
+    );
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -515,66 +515,6 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@next/env@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.1.0.tgz#73713399399b34aa5a01771fb73272b55b22c314"
-  integrity sha512-nrIgY6t17FQ9xxwH3jj0a6EOiQ/WDHUos35Hghtr+SWN/ntHIQ7UpuvSi0vaLzZVHQWaDupKI+liO5vANcDeTQ==
-
-"@next/swc-android-arm64@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@next/swc-android-arm64/-/swc-android-arm64-12.1.0.tgz#865ba3a9afc204ff2bdeea49dd64d58705007a39"
-  integrity sha512-/280MLdZe0W03stA69iL+v6I+J1ascrQ6FrXBlXGCsGzrfMaGr7fskMa0T5AhQIVQD4nA/46QQWxG//DYuFBcA==
-
-"@next/swc-darwin-arm64@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.0.tgz#08e8b411b8accd095009ed12efbc2f1d4d547135"
-  integrity sha512-R8vcXE2/iONJ1Unf5Ptqjk6LRW3bggH+8drNkkzH4FLEQkHtELhvcmJwkXcuipyQCsIakldAXhRbZmm3YN1vXg==
-
-"@next/swc-darwin-x64@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.0.tgz#fcd684497a76e8feaca88db3c394480ff0b007cd"
-  integrity sha512-ieAz0/J0PhmbZBB8+EA/JGdhRHBogF8BWaeqR7hwveb6SYEIJaDNQy0I+ZN8gF8hLj63bEDxJAs/cEhdnTq+ug==
-
-"@next/swc-linux-arm-gnueabihf@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.0.tgz#9ec6380a27938a5799aaa6035c205b3c478468a7"
-  integrity sha512-njUd9hpl6o6A5d08dC0cKAgXKCzm5fFtgGe6i0eko8IAdtAPbtHxtpre3VeSxdZvuGFh+hb0REySQP9T1ttkog==
-
-"@next/swc-linux-arm64-gnu@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.0.tgz#7f4196dff1049cea479607c75b81033ae2dbd093"
-  integrity sha512-OqangJLkRxVxMhDtcb7Qn1xjzFA3s50EIxY7mljbSCLybU+sByPaWAHY4px97ieOlr2y4S0xdPKkQ3BCAwyo6Q==
-
-"@next/swc-linux-arm64-musl@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.0.tgz#b445f767569cdc2dddee785ca495e1a88c025566"
-  integrity sha512-hB8cLSt4GdmOpcwRe2UzI5UWn6HHO/vLkr5OTuNvCJ5xGDwpPXelVkYW/0+C3g5axbDW2Tym4S+MQCkkH9QfWA==
-
-"@next/swc-linux-x64-gnu@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.0.tgz#67610e9be4fbc987de7535f1bcb17e45fe12f90e"
-  integrity sha512-OKO4R/digvrVuweSw/uBM4nSdyzsBV5EwkUeeG4KVpkIZEe64ZwRpnFB65bC6hGwxIBnTv5NMSnJ+0K/WmG78A==
-
-"@next/swc-linux-x64-musl@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.0.tgz#ea19a23db08a9f2e34ac30401f774cf7d1669d31"
-  integrity sha512-JohhgAHZvOD3rQY7tlp7NlmvtvYHBYgY0x5ZCecUT6eCCcl9lv6iV3nfu82ErkxNk1H893fqH0FUpznZ/H3pSw==
-
-"@next/swc-win32-arm64-msvc@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.0.tgz#eadf054fc412085659b98e145435bbba200b5283"
-  integrity sha512-T/3gIE6QEfKIJ4dmJk75v9hhNiYZhQYAoYm4iVo1TgcsuaKLFa+zMPh4056AHiG6n9tn2UQ1CFE8EoybEsqsSw==
-
-"@next/swc-win32-ia32-msvc@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.0.tgz#68faeae10c89f698bf9d28759172b74c9c21bda1"
-  integrity sha512-iwnKgHJdqhIW19H9PRPM9j55V6RdcOo6rX+5imx832BCWzkDbyomWnlzBfr6ByUYfhohb8QuH4hSGEikpPqI0Q==
-
-"@next/swc-win32-x64-msvc@12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.0.tgz#d27e7e76c87a460a4da99c5bfdb1618dcd6cd064"
-  integrity sha512-aBvcbMwuanDH4EMrL2TthNJy+4nP59Bimn8egqv6GHMVj0a44cU6Au4PjOhLNqEh9l+IpRGBqMTzec94UdC5xg==
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1294,11 +1234,6 @@ caniuse-lite@^1.0.0:
   version "1.0.30001304"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001304.tgz#38af55ed3fc8220cb13e35e6e7309c8c65a05559"
   integrity sha512-bdsfZd6K6ap87AGqSHJP/s1V+U6Z5lyrcbBu3ovbCCf8cSYpwTtGrCBObMpJqwxfTbLW6YTIdbb1jEeTelcpYQ==
-
-caniuse-lite@^1.0.30001283:
-  version "1.0.30001317"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001317.tgz#0548fb28fd5bc259a70b8c1ffdbe598037666a1b"
-  integrity sha512-xIZLh8gBm4dqNX0gkzrBeyI86J2eCjWzYAs40q88smG844YIrN4tVQl/RhquHvKEKImWWFIVh1Lxe5n1G/N+GQ==
 
 caniuse-lite@^1.0.30001286:
   version "1.0.30001303"
@@ -3579,29 +3514,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-next@^12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/next/-/next-12.1.0.tgz#c33d753b644be92fc58e06e5a214f143da61dd5d"
-  integrity sha512-s885kWvnIlxsUFHq9UGyIyLiuD0G3BUC/xrH0CEnH5lHEWkwQcHOORgbDF0hbrW9vr/7am4ETfX4A7M6DjrE7Q==
-  dependencies:
-    "@next/env" "12.1.0"
-    caniuse-lite "^1.0.30001283"
-    postcss "8.4.5"
-    styled-jsx "5.0.0"
-    use-subscription "1.5.1"
-  optionalDependencies:
-    "@next/swc-android-arm64" "12.1.0"
-    "@next/swc-darwin-arm64" "12.1.0"
-    "@next/swc-darwin-x64" "12.1.0"
-    "@next/swc-linux-arm-gnueabihf" "12.1.0"
-    "@next/swc-linux-arm64-gnu" "12.1.0"
-    "@next/swc-linux-arm64-musl" "12.1.0"
-    "@next/swc-linux-x64-gnu" "12.1.0"
-    "@next/swc-linux-x64-musl" "12.1.0"
-    "@next/swc-win32-arm64-msvc" "12.1.0"
-    "@next/swc-win32-ia32-msvc" "12.1.0"
-    "@next/swc-win32-x64-msvc" "12.1.0"
-
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -4190,7 +4102,7 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.5, postcss@^8.4.5:
+postcss@^8.4.5:
   version "8.4.5"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.5.tgz#bae665764dfd4c6fcc24dc0fdf7e7aa00cc77f95"
   integrity sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==
@@ -4794,11 +4706,6 @@ style-inject@^0.3.0:
   resolved "https://registry.yarnpkg.com/style-inject/-/style-inject-0.3.0.tgz#d21c477affec91811cc82355832a700d22bf8dd3"
   integrity sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==
 
-styled-jsx@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.0.tgz#816b4b92e07b1786c6b7111821750e0ba4d26e77"
-  integrity sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA==
-
 stylehacks@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-5.0.2.tgz#fa10e5181c6e8dc0bddb4a3fb372e9ac42bba2ad"
@@ -5059,13 +4966,6 @@ use-sidecar@^1.0.1, use-sidecar@^1.0.5:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^1.9.3"
-
-use-subscription@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"
-  integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
-  dependencies:
-    object-assign "^4.1.1"
 
 util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
As Iván pointed out, when opening a modal from another modal, we get an error because params are `null` for a brief moment. This will fix it, I hope.

This PR refactors the entire logic and encapsulates the whole modal state into a single object to force batch all of the different setStates, which were causing inconsistent states between modal renders, which caused `null` errors on the `params` object.