### PR TITLE
refactor(decodedUrlParams): restore no args API

### DIFF
--- a/src/URLModal.tsx
+++ b/src/URLModal.tsx
@@ -7,7 +7,7 @@ import React, {
   LazyExoticComponent,
   ElementType,
 } from 'react';
-import { MODAL_KEY, PARAMS_KEY } from './constants';
+import { MODAL_KEY } from './constants';
 import { closeModal, decodedUrlParams, store, adapters } from './helpers';
 import { useCustomEvent } from './hooks/useCustomEvent';
 import { Portal } from './Portal';
@@ -40,13 +40,12 @@ function urlIntoModalState(): ModalState {
       ? new URLSearchParams(window.location.search)
       : { get: () => null };
   const modalName = urlParams.get(MODAL_KEY);
-  const encodedParams = urlParams.get(PARAMS_KEY);
 
   if (!modalName) return { name: null, extraProps: {}, params: {} };
 
   return {
     name: modalName,
-    params: decodedUrlParams(encodedParams),
+    params: decodedUrlParams(),
     extraProps: {},
   };
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -80,11 +80,11 @@ export const encodeUrlParams = (
   obj: URLSearchParams | Record<string, unknown>
 ): string => window.btoa(encodeURI(JSON.stringify(obj)));
 
-export const decodedUrlParams = (encodedParams: string | undefined | null) => {
-  if (encodedParams) {
-    return JSON.parse(decodeURI(window.atob(encodedParams)));
+export const decodedUrlParams = () => {
+  const params = new URLSearchParams(window.location.search).get(PARAMS_KEY);
+  if (params) {
+    return JSON.parse(decodeURI(window.atob(params)));
   }
-
   return {};
 };
 
@@ -94,7 +94,7 @@ export const isModalOpen = (name: string): boolean => {
 };
 
 export const openModal = async ({ name, params, ...props }: openModalProps) => {
-  const urlParams = new URLSearchParams(cleanSearchParams());
+  const urlParams = cleanSearchParams();
 
   urlParams.set(MODAL_KEY, name);
   if (params) urlParams.set(PARAMS_KEY, encodeUrlParams(params));

--- a/src/test/helpers.test.ts
+++ b/src/test/helpers.test.ts
@@ -71,14 +71,16 @@ describe('test encodeUrlParams', () => {
 });
 
 describe('test decodedUrlParams', () => {
-  it('should decode when its URLSearchParams', () => {
-    expect(decodedUrlParams('')).toEqual({});
+  it('should decode the "params" query param from the URL', () => {
+    createFakeWindowLocation({
+      params: 'JTdCJTIyc2VhcmNoJTIyOiUyMnRlc3QlMjIlN0Q',
+    });
+    expect(decodedUrlParams()).toEqual({ search: 'test' });
   });
 
-  it('should return an empty object when nothing is passed', () => {
-    expect(decodedUrlParams('JTdCJTIyc2VhcmNoJTIyOiUyMnRlc3QlMjIlN0Q')).toEqual(
-      { search: 'test' }
-    );
+  it('should return an empty object when there is no "params" query param in the URL', () => {
+    createFakeWindowLocation({});
+    expect(decodedUrlParams()).toEqual({});
   });
 });
 


### PR DESCRIPTION
In [this commit](https://github.com/remoteoss/react-url-modal/pull/30/files#diff-ca5696b367d474e785317cb7a0d9853fef5729387ab8d0fab4c46268c03aae99R83) we accidentally changed the API of the `decodedUrlParams` function.

This PR reverts that change to make the function API accept no arguments.