### PR TITLE
chore: use Next.js 12 as peer dependency for backward compatibility with React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "main": "dist/react-url-modal.cjs.js",
   "module": "dist/react-url-modal.esm.js",
@@ -62,7 +62,7 @@
     "zustand": "^4.3.8"
   },
   "peerDependencies": {
-    "next": "^13.4.4",
+    "next": ">=12",
     "react": ">=16",
     "react-dom": ">=16"
   },


### PR DESCRIPTION
This pull request modifies the peerDependencies in `package.json `to specify `Next.js 12` instead of `Next.js 13`. The intention behind this change is to maintain backward compatibility with `React 17`.

Many of our users are still using `React 17` with `Next.js 12` in their projects. By updating our peer dependency to allow `Next.js 12`, we can ensure our package continues to work for these users. 
